### PR TITLE
fix: small text with icon in a flex container

### DIFF
--- a/src/lib/components/ui/typography.svelte
+++ b/src/lib/components/ui/typography.svelte
@@ -58,6 +58,7 @@
 
 <style>
 	.root {
+		display: inherit;
 		margin: 0;
 		padding: 0;
 		color: var(--colors-ultra-high);


### PR DESCRIPTION
resolved #342 